### PR TITLE
Default unit to hours - PMT #104842

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     description="simple duration parsing library",
     long_description="convert human readable durations to python timedeltas",
     install_requires = [""],
+    tests_require=['nose'],
     scripts = [],
     license = "BSD",
     platforms = ["any"],

--- a/simpleduration/duration.py
+++ b/simpleduration/duration.py
@@ -77,8 +77,12 @@ class Duration(object):
             self.seconds += parse_single(n, u)
         else:
             if len(n_parts) > 0:
-                # we have a number but no units
-                raise InvalidDuration
+                # we have a number but no units. In this case,
+                # assume the unit is hours.
+                u_parts.append('h')
+                u = ''.join(u_parts)
+                n = ''.join(n_parts)
+                self.seconds += parse_single(n, u)
 
     def timedelta(self):
         return timedelta(seconds=self.seconds)

--- a/simpleduration/test/test_durations.py
+++ b/simpleduration/test/test_durations.py
@@ -18,6 +18,9 @@ SINGLE_TEST_CASES = [
     ("1.5HOURS", 5400),
     ("1.5 HOURS", 5400),
     ("1 day", 3600 * 24),
+    ("13", 3600 * 13),
+    ("1", 3600),
+    ("24", 3600 * 24),
 ]
 
 COMBINED_TEST_CASES = [
@@ -30,9 +33,11 @@ COMBINED_TEST_CASES = [
 ]
 
 INVALID_TEST_CASES = [
+    # TODO: strings like this should be invalid:
+    # "30 40 minutes",
+    # "13 13",
     "1foo",
     "bar",
-    "13",
     "minute1",
 ]
 


### PR DESCRIPTION
This is up for debate, let me know what you think about this - Maurice thinks the time unit should default to hours. Currently, entering a simpleduration with no unit into PMT is a bit broken.. it creates the time object and always gives it a duration of 0. This change would fix that behavior, but we could also solve it by telling the user they need to enter a time unit when they don't include one.
